### PR TITLE
1. Bug fix.  2. add fast long retention implement

### DIFF
--- a/retnet/configuration_retnet.py
+++ b/retnet/configuration_retnet.py
@@ -36,7 +36,7 @@ class RetNetConfig(PretrainedConfig):
     use_ffn_rms_norm: bool = False
     layernorm_eps: float = 1e-6
     tie_word_embeddings: bool = False
-
+    
     def __init__(
             self,
             vocab_size: int = 50257,
@@ -60,7 +60,7 @@ class RetNetConfig(PretrainedConfig):
             layernorm_embedding: bool = False,  # add layernorm to embedding
             no_scale_embedding: bool = True,  # if True, dont scale embeddings
             recurrent_chunk_size: int = 512,
-            use_glu: bool = True,  # use GLU instead of FFN
+            use_glu: bool = False,  # use GLU instead of FFN
             z_loss_coeff: float = 0.0,  # coefficient for z loss: TODO: 1e-4
             use_lm_decay: bool = False,
             deepnorm: bool = False,
@@ -68,6 +68,7 @@ class RetNetConfig(PretrainedConfig):
             use_ffn_rms_norm: bool = False,  # use RMSNorm instead of LayerNorm in FFN
             layernorm_eps: float = 1e-6,
             tie_word_embeddings: bool = False,
+            use_flash_retention: bool = False,
             **kwargs):
         self.vocab_size = vocab_size
         self.initializer_range = initializer_range
@@ -96,7 +97,7 @@ class RetNetConfig(PretrainedConfig):
         # Blockwise
         self.recurrent_chunk_size = recurrent_chunk_size
         self.forward_impl = forward_impl
-
+        self.use_flash_retention = use_flash_retention
         if self.deepnorm:
             self.decoder_normalize_before = False
             self.subln = False


### PR DESCRIPTION
1. Fix bug for the  mode with inputs_embedding rather than inputs_ids
```
if inputs_embeds is None:
    inputs_embeds = self.forward_embedding(input_ids, forward_impl, inputs_embeds,past_key_values)
else:
    if forward_impl == 'recurrent':
        inputs_embeds = inputs_embeds[:, -1:]
```
2. Add fix length seq arguement when the inputs is (addtional_token, pask_kv) 
```
if fixed_seq_len:slen=fixed_seq_len
```
3. Cached the fixed retnet_rel_pos ( thus does not need generate runtimely)

4. add fast retention implement when the sequence length >> D**2.
See `https://github.com/veya2ztn/fast_retention`

5.1 I set `use_glu` defaut to false, thus consistancy to old code.
5.2 The layer norm setting in FFN seem wrong, the `self.embed_dim should` be `ffn_dim`
```
if subln:
    if use_rms_norm:
        self.ffn_layernorm = RMSNorm(self.embed_dim, eps=layernorm_eps)
    else:
        self.ffn_layernorm = LayerNorm(self.embed_dim, eps=layernorm_eps)
else:
    self.ffn_layernorm = None
```
Anyway, I roll back to `self.ffn_layernorm = LayerNorm(ffn_dim, eps=layernorm_eps) if subln else None`